### PR TITLE
compute correct axis limits in marginalhist

### DIFF
--- a/src/marginalhist.jl
+++ b/src/marginalhist.jl
@@ -3,8 +3,9 @@
 @recipe function f(::Type{Val{:marginalhist}}, plt::AbstractPlot; density = false)
     x, y = plotattributes[:x], plotattributes[:y]
     bns = get(plotattributes, :bins, :auto)
+    scale = get(plotattributes, :scale, :identity)
     edges1, edges2 = Plots._hist_edges((x,y), bns)
-    xlims, ylims = Plots.ignorenan_extrema(x), Plots.ignorenan_extrema(y)
+    xlims, ylims = Plots.widen(Plots.ignorenan_extrema(x)..., scale), Plots.widen(Plots.ignorenan_extrema(y)..., scale)
 
     # set up the subplots
     legend --> false

--- a/src/marginalhist.jl
+++ b/src/marginalhist.jl
@@ -4,6 +4,7 @@
     x, y = plotattributes[:x], plotattributes[:y]
     bns = get(plotattributes, :bins, :auto)
     edges1, edges2 = Plots._hist_edges((x,y), bns)
+    xlims, ylims = Plots.ignorenan_extrema(x), Plots.ignorenan_extrema(y)
 
     # set up the subplots
     legend --> false
@@ -21,6 +22,8 @@
         top_margin --> 0mm
         subplot := 2
         bins := (edges1, edges2)
+        xlims --> xlims
+        ylims --> ylims
     end
 
     # these are common to both marginal histograms
@@ -44,6 +47,7 @@
         bottom_margin --> 0mm
         bins := edges1
         y := x
+        xlims --> xlims
     end
 
     # right histogram
@@ -53,6 +57,7 @@
         left_margin --> 0mm
         bins := edges2
         y := y
+        xlims --> ylims
     end
 end
 


### PR DESCRIPTION
This tries to fix some of the issues of #178 by manually setting `xlims` and `ylims` (unless the user provides them) correctly for 2d and 1d histograms.