### PR TITLE
[WIP] Fix stacked groupedbar with pos and neg vals

### DIFF
--- a/src/bar.jl
+++ b/src/bar.jl
@@ -7,12 +7,54 @@ end
 grouped_xy(x::AbstractVector, y::AbstractMatrix) = x, y
 grouped_xy(y::AbstractMatrix) = 1:size(y,1), y
 
+function homogenous_signs(y::AbstractMatrix)
+     for i in 1:size(y, 1)
+        sgn = 0.0
+        for j in 1:size(y,2)
+            testsgn = sign(y[i,j])
+            if sgn == 0.0
+                sgn = testsgn
+            end
+            if sgn != testsgn && testsgn != 0.0
+                return false
+            end
+        end
+    end
+    true
+end
+
+function groupedbar_fillrange(y::AbstractMatrix)
+    nr, nc = size(y)
+    y = copy(y)
+        y[.!isfinite.(y)] .= 0
+        fr = zeros(nr, nc)
+        for c=2:nc
+            for r=1:nr
+                fr[r,c] = y[r,c-1]
+                y[r,c] += fr[r,c]
+            end
+        end
+        y, fr
+end
+
+#=
+    @assert homogenous_signs(rand(10,3))
+    @assert homogenous_signs([-0.5 0.0 0.5; rand(9,3)]) == false
+    @assert homogenous_signs([rand(9,3); -0.5 0.0 -0.5]) == true
+    @assert homogenous_signs([-rand(9,3); 0.5 -0.0 0.5]) == true
+=#
+
 @recipe function f(g::GroupedBar)
     x, y = grouped_xy(g.args...)
 
     nr, nc = size(y)
     isstack = pop!(plotattributes, :bar_position, :dodge) == :stack
-
+    
+    if isstack && !homogenous_signs(y)
+        y_neg = y .* (y .< 0)
+        y_pos = y .* (y .> 0)
+    end
+        
     # extract xnums and set default bar width.
     # might need to set xticks as well
     xnums = if eltype(x) <: Number
@@ -45,17 +87,18 @@ grouped_xy(y::AbstractMatrix) = 1:size(y,1), y
     end
 
     # compute fillrange
-    fillrange := if isstack
-        # shift y/fillrange up
-        y = copy(y)
-        y[.!isfinite.(y)] .= 0
-        fr = zeros(nr, nc)
-        for c=2:nc
-            for r=1:nr
-                fr[r,c] = y[r,c-1]
-                y[r,c] += fr[r,c]
-            end
+    if isstack
+        if homogenous_signs(y)
+            y, fr = groupedbar_fillrange(y)
+        else
+            y_neg, fr_neg = groupedbar_fillrange(y_neg)
+            y_pos, fr_pos = groupedbar_fillrange(y_pos)
+            y = [y_neg, y_pos]
+            fr = [fr_neg, fr_pos]
         end
+    end
+    
+    fillrange := if isstack
         fr
     else
         get(plotattributes, :fillrange, nothing)

--- a/src/bar.jl
+++ b/src/bar.jl
@@ -36,7 +36,7 @@ end
     # if :stack, check if the signs are constant within each group
     constant_signs = isstack ? constant_sign_rowwise(y) : true
     # if not, split the data into a positive and negative parts
-    if isstack && !constant_signs    
+    if isstack && !constant_signs
         y_neg = y .* (y .< 0)
         y_pos = y .* (y .> 0)
     end
@@ -72,6 +72,9 @@ end
         xmat
     end
 
+    # colors
+    group_id = [j for i in 1:nr, j in 1:nc]
+
     # compute fillrange
     if isstack
         if constant_signs
@@ -79,8 +82,18 @@ end
         else
             y_neg, fr_neg = groupedbar_fillrange(y_neg)
             y_pos, fr_pos = groupedbar_fillrange(y_pos)
-            y = [y_neg, y_pos]
-            fr = [fr_neg, fr_pos]
+            @series begin
+                seriestype := :bar
+                x := x
+                y := y_neg
+                fillrange := fr_neg
+                label := ""
+                color := group_id
+                primary := false
+                ()
+            end
+            y = y_pos
+            fr = fr_pos
         end
     end
 
@@ -91,5 +104,6 @@ end
     end
 
     seriestype := :bar
+    color := group_id
     x, y
 end

--- a/src/bar.jl
+++ b/src/bar.jl
@@ -7,54 +7,40 @@ end
 grouped_xy(x::AbstractVector, y::AbstractMatrix) = x, y
 grouped_xy(y::AbstractMatrix) = 1:size(y,1), y
 
-function homogenous_signs(y::AbstractMatrix)
-     for i in 1:size(y, 1)
-        sgn = 0.0
-        for j in 1:size(y,2)
-            testsgn = sign(y[i,j])
-            if sgn == 0.0
-                sgn = testsgn
-            end
-            if sgn != testsgn && testsgn != 0.0
-                return false
-            end
-        end
-    end
-    true
+constant_sign(x) = all(t -> t >= 0, x) || all(t -> t <= 0, x)
+function constant_sign_rowwise(x::AbstractMatrix)
+    nr, nc = size(x)
+    all(constant_sign(x[i, j] for j in 1:nc) for i in 1:nr)
 end
 
 function groupedbar_fillrange(y::AbstractMatrix)
     nr, nc = size(y)
     y = copy(y)
-        y[.!isfinite.(y)] .= 0
-        fr = zeros(nr, nc)
-        for c=2:nc
-            for r=1:nr
-                fr[r,c] = y[r,c-1]
-                y[r,c] += fr[r,c]
-            end
+    y[.!isfinite.(y)] .= 0
+    fr = zeros(nr, nc)
+    for c=2:nc
+        for r=1:nr
+            fr[r,c] = y[r,c-1]
+            y[r,c] += fr[r,c]
         end
-        y, fr
+    end
+    y, fr
 end
-
-#=
-    @assert homogenous_signs(rand(10,3))
-    @assert homogenous_signs([-0.5 0.0 0.5; rand(9,3)]) == false
-    @assert homogenous_signs([rand(9,3); -0.5 0.0 -0.5]) == true
-    @assert homogenous_signs([-rand(9,3); 0.5 -0.0 0.5]) == true
-=#
 
 @recipe function f(g::GroupedBar)
     x, y = grouped_xy(g.args...)
 
     nr, nc = size(y)
     isstack = pop!(plotattributes, :bar_position, :dodge) == :stack
-    
-    if isstack && !homogenous_signs(y)
+
+    # if :stack, check if the signs are constant within each group
+    constant_signs = isstack ? constant_sign_rowwise(y) : true
+    # if not, split the data into a positive and negative parts
+    if isstack && !constant_signs    
         y_neg = y .* (y .< 0)
         y_pos = y .* (y .> 0)
     end
-        
+
     # extract xnums and set default bar width.
     # might need to set xticks as well
     xnums = if eltype(x) <: Number
@@ -88,7 +74,7 @@ end
 
     # compute fillrange
     if isstack
-        if homogenous_signs(y)
+        if constant_signs
             y, fr = groupedbar_fillrange(y)
         else
             y_neg, fr_neg = groupedbar_fillrange(y_neg)
@@ -97,7 +83,7 @@ end
             fr = [fr_neg, fr_pos]
         end
     end
-    
+
     fillrange := if isstack
         fr
     else

--- a/test/bar.jl
+++ b/test/bar.jl
@@ -1,0 +1,8 @@
+import StatPlots: constant_sign_rowwise
+
+@testset "groupedbar" begin
+    @test constant_sign_rowwise(rand(10,3))
+    @test constant_sign_rowwise([-0.5 0.0 0.5; rand(9,3)]) == false
+    @test constant_sign_rowwise([rand(9,3); -0.5 0.0 -0.5]) == true
+    @test constant_sign_rowwise([-rand(9,3); 0.5 -0.0 0.5]) == true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using StatPlots
 using Test
 
-# write your own tests here
-@test 1 == 1
+include("bar.jl")


### PR DESCRIPTION

The code for `groupedbar` assumes that the values for each group have the same sign.

The following code illustrates the problem.
```julia
y = [-rand(1,3); rand(1,3); [-0.5 0.1 0.5]]

groupedbar(y, bar_position = :stack) 
# consider the very right bars: the positive entries are misplaced, the negative entry is missing
```

![wrong](https://user-images.githubusercontent.com/6280307/46261514-e0f4bd00-c4f4-11e8-9593-a4e3a68b9d2e.png)

```julia
# This can be fixed by something like this
y_pos = y .* (y .> 0)
y_neg = y .* (y .< 0) 
groupedbar(y_pos, bar_position = :stack)
groupedbar!(y_neg, bar_position = :stack)
```

![almostright](https://user-images.githubusercontent.com/6280307/46261516-e6ea9e00-c4f4-11e8-9c44-4b54c1a5fbb9.png)


I started to go this way for this PR.

Problems that I face
1. The colors don't match (the negative part gets new colors and labels)
2. I would like to use something like `@series` (as in `margindensity` code), but `groupedbar` is not a series

This is my first PR. This is the first time I am working with recipes. I would appreciate your help on this.