### PR TITLE
Fix dendrogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Original author: Thomas Breloff (@tbreloff), maintained by the JuliaPlots members
 
-This package is a drop-in replacement for Plots.jl that contains many statistical recipes for concepts and types introduced in the JuliaStats organization. 
+This package is a drop-in replacement for Plots.jl that contains many statistical recipes for concepts and types introduced in the JuliaStats organization.
 
 - Types:
     - DataFrames
@@ -292,7 +292,7 @@ groupedbar(nam, rand(5, 2), group = ctg, xlabel = "Groups", ylabel = "Scores",
 using Clustering
 D = rand(10, 10)
 D += D'
-hc = hclust(D, :single)
+hc = hclust(D, linkage=:single)
 plot(hc)
 ```
 

--- a/src/StatsPlots.jl
+++ b/src/StatsPlots.jl
@@ -15,7 +15,7 @@ using Widgets, Observables
 import Observables: AbstractObservable, @map, observe
 import Widgets: @nodeps
 import DataStructures: OrderedDict
-import Clustering: Hclust
+import Clustering: Hclust, nnodes
 
 import KernelDensity
 @recipe f(k::KernelDensity.UnivariateKDE) = k.x, k.density

--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -2,15 +2,15 @@ function treepositions(hc::Hclust, useheight::Bool)
     order = StatsBase.indexmap(hc.order)
     nodepos = Dict(-i => (float(order[i]), 0.0) for i in hc.order)
 
-    xs = Array{Float64}(undef, 4, size(hc.merge, 1))
-    ys = Array{Float64}(undef, 4, size(hc.merge, 1))
+    xs = Array{Float64}(undef, 4, size(hc.merges, 1))
+    ys = Array{Float64}(undef, 4, size(hc.merges, 1))
 
-    for i in 1:size(hc.merge, 1)
-        x1, y1 = nodepos[hc.merge[i, 1]]
-        x2, y2 = nodepos[hc.merge[i, 2]]
+    for i in 1:size(hc.merges, 1)
+        x1, y1 = nodepos[hc.merges[i, 1]]
+        x2, y2 = nodepos[hc.merges[i, 2]]
 
         xpos = (x1 + x2) / 2
-        useheight ? h = hc.height[i] : h = 1
+        useheight ? h = hc.heights[i] : h = 1
         ypos = max(y1, y2) + h
 
         nodepos[i] = (xpos, ypos)
@@ -30,7 +30,7 @@ end
     xlims := (0.5, length(hc.order) + 0.5)
 
     linecolor --> :black
-    xticks --> (1:length(hc.labels), hc.labels[hc.order])
+    xticks --> (1:nnodes(hc), (1:nnodes(hc))[hc.order])
     ylims --> (0, Inf)
     yshowaxis --> useheight
 

--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -2,8 +2,8 @@ function treepositions(hc::Hclust, useheight::Bool)
     order = StatsBase.indexmap(hc.order)
     nodepos = Dict(-i => (float(order[i]), 0.0) for i in hc.order)
 
-    xs = Array{Float64}(4, size(hc.merge, 1))
-    ys = Array{Float64}(4, size(hc.merge, 1))
+    xs = Array{Float64}(undef, 4, size(hc.merge, 1))
+    ys = Array{Float64}(undef, 4, size(hc.merge, 1))
 
     for i in 1:size(hc.merge, 1)
         x1, y1 = nodepos[hc.merge[i, 1]]


### PR DESCRIPTION
Before this PR:

```julia
julia> using StatsPlots, Clustering

julia> D = rand(10, 10);

julia> D += D';

julia> hc = hclust(D, :single)
┌ Warning: `hclust(d, method::Symbol, uplo::Union{Symbol, Nothing}=nothing)` is deprecated, use `hclust(d, linkage=method, uplo=uplo)` instead.
│   caller = hclust(::Array{Float64,2}, ::Symbol) at deprecated.jl:56
└ @ Clustering ./deprecated.jl:56
Hclust{Float64}([-1 -10; -3 1; … ; -8 7; -4 8], [0.226407, 0.245509, 0.263479, 0.379633, 0.51582, 0.590481, 0.599298, 0.732391, 0.920357], [4, 8, 6, 2, 9, 5, 7, 3, 1, 10], :single)

julia> plot(hc)
┌ Warning: Hclust::labels is deprecated and will be removed in future versions
│   caller = ip:0x0
└ @ Core :-1
┌ Warning: Hclust::merge is deprecated, use Hclust::merges
│   caller = ip:0x0
└ @ Core :-1
ERROR: MethodError: no method matching Array{Float64,N} where N(::Int64, ::Int64)
Closest candidates are:
  Array{Float64,N} where N(::UndefInitializer, ::Int64) where T at boot.jl:416
  Array{Float64,N} where N(::UndefInitializer, ::Int64, ::Int64) where T at boot.jl:417
  Array{Float64,N} where N(::UndefInitializer, ::Int64, ::Int64, ::Int64) where T at boot.jl:418
  ...
Stacktrace:
 [1] treepositions(::Hclust{Float64}, ::Bool) at /Users/harry/.julia/packages/StatsPlots/yNokW/src/dendrogram.jl:5
 [2] apply_recipe(::Dict{Symbol,Any}, ::Hclust{Float64}) at /Users/harry/.julia/packages/RecipesBase/Uz5AO/src/RecipesBase.jl:275
 [3] _process_userrecipes(::Plots.Plot{Plots.GRBackend}, ::Dict{Symbol,Any}, ::Tuple{Hclust{Float64}}) at /Users/harry/.julia/packages/Plots/UQI78/src/pipeline.jl:83
 [4] _plot!(::Plots.Plot{Plots.GRBackend}, ::Dict{Symbol,Any}, ::Tuple{Hclust{Float64}}) at /Users/harry/.julia/packages/Plots/UQI78/src/plot.jl:178
 [5] #plot#136(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Hclust{Float64}) at /Users/harry/.julia/packages/Plots/UQI78/src/plot.jl:57
 [6] plot(::Hclust{Float64}) at /Users/harry/.julia/packages/Plots/UQI78/src/plot.jl:51
 [7] top-level scope at none:0
```

Now:
![kill](https://user-images.githubusercontent.com/10820071/52791858-d846f280-3061-11e9-9d82-2c912e4b9eec.png)
