### PR TITLE
WIP: clustered heatmap aka clustermap

### DIFF
--- a/src/StatsPlots.jl
+++ b/src/StatsPlots.jl
@@ -37,5 +37,6 @@ include("marginalhist.jl")
 include("bar.jl")
 include("dendrogram.jl")
 include("andrews.jl")
+include("clustermap.jl")
 
 end # module

--- a/src/clustermap.jl
+++ b/src/clustermap.jl
@@ -1,0 +1,48 @@
+@userplot Clustermap
+
+recipetype(::Val{:clustermap}, args...) = Clustermap(args)
+
+@recipe function f(cm::Clustermap)
+    if length(cm.args) == 3
+        M, hc, ticklabels = cm.args
+    elseif length(cm.args) == 2
+        M, hc = cm.args
+        ticklabels = 1:nnodes(hc)
+    end
+
+    layout --> @layout [
+        topdendrogram      _
+        heatmap{0.9w,0.9h} rightdendrogram
+    ]
+
+    legend := false
+    link := :both
+    margin --> 0mm
+    grid --> false
+
+    @series begin
+        seriestype := :heatmap
+        subplot := 2
+        ticks --> (1:nnodes(hc), ticklabels[hc.order])
+        # TODO The colorbar is placed on the right hand side of the heatmap subplot. This
+        # squashes the heatmap, which makes the topdendrogram be misaligned. Is it possible
+        # to add the colorbar to the empty top-right subplot?
+        # colorbar --> true
+        M[hc.order, hc.order]
+    end
+
+    axis := :off
+
+    # topdendrogram
+    @series begin
+        subplot := 1
+        hc
+    end
+
+    # rightdendrogram
+    @series begin
+        subplot := 3
+        horizontal := true
+        hc
+    end
+end

--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -21,7 +21,7 @@ function treepositions(hc::Hclust, useheight::Bool)
     return xs, ys
 end
 
-@recipe function f(hc::Hclust; useheight=true)
+@recipe function f(hc::Hclust; useheight=true, horizontal=false)
     typeof(useheight) <: Bool || error("'useheight' argument must be true or false")
 
     legend := false
@@ -34,5 +34,6 @@ end
     ylims --> (0, Inf)
     yshowaxis --> useheight
 
-    treepositions(hc, useheight)
+    xs, ys = treepositions(hc, useheight)
+    horizontal ? (ys, xs) : (xs, ys)
 end


### PR DESCRIPTION
Clustered heatmap like `seaborn.clustermap` in Python and something similar in R.

```julia
using StatsPlots, Statistics, Clustering, Distances
M = rand(10,10)
M = cor(M)
hc = hclust(pairwise(Euclidean(), M))
clustermap(M, hc, [["A", "B", "C"]; 4:10])
savefig("clustermap.png")
```

![clustermap](https://user-images.githubusercontent.com/10820071/52844735-2d841200-30fd-11e9-87f3-068ee7a9d747.png)

This starts to look a bit messy with larger matrices:

```julia
M = rand(50,50)
M = cor(M)
hc = hclust(pairwise(Euclidean(), M))
clustermap(M, hc)
savefig("clustermap2.png")
```

![clustermap2](https://user-images.githubusercontent.com/10820071/52845334-c23b3f80-30fe-11e9-9440-83e7399dae01.png)


### To do

- [ ] Add colorbar to top right subplot. Is this possible?
- [ ] Improve alignment of dendrograms to heatmap

I would appreciate any comments or help polishing this up!

NB requires #213 to work.