### PR TITLE
Optionally show mean, median and quantiles in violin (Fix #127)

### DIFF
--- a/src/violin.jl
+++ b/src/violin.jl
@@ -19,7 +19,7 @@ get_quantiles(x::Real) = [x]
 get_quantiles(b::Bool) = b ? [0.5] : Float64[]
 get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
-@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, median = false, quantiles = Float64[])
+@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, mean = false, median = false, quantiles = Float64[])
     # if only y is provided, then x will be UnitRange 1:length(y)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
@@ -60,10 +60,31 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
             ()
         end
 
+        if mean
+            mea = StatsBase.mean(fy)
+            mw = maximum(widths)
+            mx = xcenter .+ [-mw, mw] * 0.75
+            my = [mea, mea]
+            if side == :right
+                mx[1] = xcenter
+            elseif side == :left
+                mx[2] = xcenter
+            end
+
+            @series begin
+                primary := false
+                seriestype := :shape
+                linestyle := :dot
+                x := mx
+                y := my
+                ()
+            end
+        end
+
         if median
             med = StatsBase.median(fy)
             mw = maximum(widths)
-            mx = xcenter .+ [-mw[i], mw[i]] / 2
+            mx = xcenter .+ [-mw, mw] / 2
             my = [med, med]
             if side == :right
                 mx[1] = xcenter

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -14,8 +14,12 @@ function violin_coords(y; trim::Bool=false)
     kd.density, kd.x
 end
 
+get_quantiles(quantiles::AbstractVector) = quantiles
+get_quantiles(x::Real) = [x]
+get_quantiles(b::Bool) = b ? [0.5] : Float64[]
+get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
-@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both)
+@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, median = false, quantiles = Float64[])
     # if only y is provided, then x will be UnitRange 1:length(y)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
@@ -28,6 +32,7 @@ end
     glabels = sort(collect(unique(x)))
     bw = plotattributes[:bar_width]
     bw == nothing && (bw = 0.8)
+    msc = plotattributes[:markerstrokecolor]
     for (i,glabel) in enumerate(glabels)
         widths, centers = violin_coords(y[filter(i -> _cycle(x,i) == glabel, 1:length(y))], trim=trim)
         isempty(widths) && continue
@@ -47,17 +52,72 @@ end
         end
         ycoords = vcat(centers, reverse(centers))
 
-        push!(xsegs, xcoords)
-        push!(ysegs, ycoords)
+        @series begin
+            seriestype := :shape
+            x := xcoords
+            y := ycoords
+            ()
+        end
+
+        if median
+            med = StatsBase.median(y)
+            mw = maximum(widths)
+            mx = xcenter .+ [-mw[i], mw[i]] / 2
+            my = [med, med]
+            if side == :right
+                mx[1] = xcenter
+            elseif side == :left
+                mx[2] = xcenter
+            end
+
+            @series begin
+                primary := false
+                seriestype := :shape
+                x := mx
+                y := my
+                ()
+            end
+        end
+
+        quantiles = get_quantiles(quantiles)
+        if !isempty(quantiles)
+            qy = quantile(y, quantiles)
+            maxw = maximum(widths)
+
+            for i in eachindex(qy)
+                qxi = xcenter .+ [-maxw, maxw] * (0.5 - abs(0.5 - quantiles[i]))
+                qyi = [qy[i], qy[i]]
+                if side == :right
+                    qxi[1] = xcenter
+                elseif side == :left
+                    qxi[2] = xcenter
+                end
+
+                @series begin
+                    primary := false
+                    seriestype := :shape
+                    x := qxi
+                    y := qyi
+                    ()
+                end
+            end
+
+            @series begin
+                primary :=false
+                seriestype := :shape
+                x := [xcenter, xcenter]
+                y := [extrema(qy)...]
+            end
+        end
     end
 
     seriestype := :shape
-    x := xsegs.pts
-    y := ysegs.pts
+    primary := false
+    x := []
+    y := []
     ()
 end
 Plots.@deps violin shape
-
 
 # ------------------------------------------------------------------------------
 # Grouped Violin

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -34,7 +34,8 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
     bw == nothing && (bw = 0.8)
     msc = plotattributes[:markerstrokecolor]
     for (i,glabel) in enumerate(glabels)
-        widths, centers = violin_coords(y[filter(i -> _cycle(x,i) == glabel, 1:length(y))], trim=trim)
+        fy = y[filter(i -> _cycle(x,i) == glabel, 1:length(y))]
+        widths, centers = violin_coords(fy, trim=trim)
         isempty(widths) && continue
 
         # normalize
@@ -60,7 +61,7 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
         end
 
         if median
-            med = StatsBase.median(y)
+            med = StatsBase.median(fy)
             mw = maximum(widths)
             mx = xcenter .+ [-mw[i], mw[i]] / 2
             my = [med, med]
@@ -81,7 +82,7 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
         quantiles = get_quantiles(quantiles)
         if !isempty(quantiles)
-            qy = quantile(y, quantiles)
+            qy = quantile(fy, quantiles)
             maxw = maximum(widths)
 
             for i in eachindex(qy)

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -19,7 +19,7 @@ get_quantiles(x::Real) = [x]
 get_quantiles(b::Bool) = b ? [0.5] : Float64[]
 get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
-@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, mean = false, median = false, quantiles = Float64[])
+@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, show_mean = false, show_median = false, quantiles = Float64[])
     # if only y is provided, then x will be UnitRange 1:length(y)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
@@ -60,7 +60,7 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
             ()
         end
 
-        if mean
+        if show_mean
             mea = StatsBase.mean(fy)
             mw = maximum(widths)
             mx = xcenter .+ [-mw, mw] * 0.75
@@ -81,7 +81,7 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
             end
         end
 
-        if median
+        if show_median
             med = StatsBase.median(fy)
             mw = maximum(widths)
             mx = xcenter .+ [-mw, mw] / 2


### PR DESCRIPTION
This adds the kwargs `mean`, `median` and `quantiles` to the violin recipe. `mean` and `median` accept Bools. `quantiles` accepts a vector of quantiles or an integer for evenly spaced quantiles. Quantiles are shown as a solid line and the mean is plotted as a dotted line. I'm open for other ideas and suggestions.

cc: @yakir12

```julia
using StatsPlots
y = [i * randn(100) for i in 1:4]
```
```julia
violin(y, median = true)
```
![violin1](https://user-images.githubusercontent.com/16589944/52922910-ee380a00-3324-11e9-804f-3750479fb743.png)

```julia
violin(y, quantiles = [0.1, 0.5, 0.9], linecolor = :white, linewidth = 3)
```
![violin2](https://user-images.githubusercontent.com/16589944/52922912-f728db80-3324-11e9-94ab-767188218609.png)

```julia
violin(y, quantiles = 5, trim = false, linecolor = :match, fillalpha = 0.3)
```
![violin3](https://user-images.githubusercontent.com/16589944/52922921-ff811680-3324-11e9-8d92-93fdf018dc2f.png)

```julia
violin(y, quantiles = 3,  mean = true)
```
![violin4](https://user-images.githubusercontent.com/16589944/52922932-0a3bab80-3325-11e9-9c98-8da028b1e151.png)
