### PR TITLE
Simplify interface and port groupedviolin/boxplot to standard plots grouping

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,7 +9,7 @@ IterableTables 0.5
 TableTraitsUtils 0.1
 TableTraits
 DataValues
-Widgets 0.4.0
+Widgets 0.5.0
 Observables 0.2.2
 DataStructures
 Clustering

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -146,12 +146,13 @@ recipetype(::Val{:groupedboxplot}, args...) = GroupedBoxplot(args)
     # shift x values for each group
     group = get(plotattributes, :group, nothing)
     if group != nothing
-        ug = unique(group)
-        n = length(ug)
+        gb = Plots.extractGroupArgs(group)
+        labels, idxs = getfield(gb, 1), getfield(gb, 2)
+        n = length(labels)
         bws = plotattributes[:bar_width] / n
         bar_width := bws * clamp(1 - spacing, 0, 1)
         for i in 1:n
-            groupinds = findall(isequal(ug[i]), group)
+            groupinds = idxs[i]
             Δx = _cycle(bws, i) * (i - (n + 1) / 2)
             x[groupinds] .+= Δx
         end

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -1,3 +1,8 @@
+plot_function(plt::Function, grouped) = plt
+plot_function(plt::Tuple, grouped) = grouped ? plt[2] : plt[1]
+
+combine_cols(dict, ns) = length(ns) > 1 ? hcat((dict[n] for n in ns)...) : dict[ns[1]]
+
 function dataviewer(t; throttle = 0.1, nbins = 30, nbins_range = 1:100)
     (t isa AbstractObservable) || (t = Observable{Any}(t))
 
@@ -13,14 +18,15 @@ function dataviewer(t; throttle = 0.1, nbins = 30, nbins_range = 1:100)
         OrderedDict(
             "line"         => Plots.plot,
             "scatter"      => Plots.scatter,
-            "bar"          => StatsPlots.groupedbar,
-            "boxplot"      => StatsPlots.boxplot,
+            "bar"          => (Plots.bar, StatsPlots.groupedbar),
+            "boxplot"      => (StatsPlots.boxplot, StatsPlots.groupedboxplot),
             "corrplot"     => StatsPlots.corrplot,
             "cornerplot"   => StatsPlots.cornerplot,
             "density"      => StatsPlots.density,
+            "cdensity"     => StatsPlots.cdensity,
             "histogram"    => StatsPlots.histogram,
             "marginalhist" => StatsPlots.marginalhist,
-            "violin"       => StatsPlots.violin
+            "violin"       => (StatsPlots.violin, StatsPlots.groupedviolin),
         ),
         placeholder = "Plot type")
 
@@ -34,23 +40,41 @@ function dataviewer(t; throttle = 0.1, nbins = 30, nbins_range = 1:100)
     by_toggle = Widgets.togglecontent(by, value = false, label = "Split data")
     plt = Widgets.button("plot")
     output = @map begin
-        &plt
-        if (plt[] == 0)
+        if (&plt == 0)
             plot()
         else
-            x_cols = hcat(getindex.((&dict,), x[])...)
+            args = Any[]
+            # add first and maybe second argument
+            push!(args, combine_cols(&dict, x[]))
             has_y = y_toggle[] && !isempty(y[])
+            has_y && push!(args, combine_cols(&dict, y[]))
+
+            # compute automatic kwargs
+            kwargs = Dict()
+
+            # grouping kwarg
             has_by = by_toggle[] && !isempty(by[])
-            y_cols = has_y ? [hcat(getindex.((&dict,), y[])...)] : []
             by_tup = Tuple(getindex(&dict, b) for b in by[])
-            by_kwarg = has_by ? [(:group, NamedTuple{Tuple(by[])}(by_tup))] : []
-            label = length(x[]) > 1 ? [(:label, x[])] :
-                    (y_toggle[] && length(y[]) > 1) ? [(:label, y[])] : []
-            densityplot1D = plot_type[] in [density, histogram]
-            xlabel = (length(x[]) == 1 && (densityplot1D || has_y)) ? [(:xlabel, x[][1])] : []
-            ylabel = (has_y && length(y[]) == 1) ? [(:ylabel, y[][1])] :
-                     (!has_y && !densityplot1D && length(x[]) == 1) ? [(:ylabel, x[][1])] : []
-            plot_type[](x_cols, y_cols...; nbins = &nbins_throttle, by_kwarg..., label..., xlabel..., ylabel...)
+            has_by && (kwargs[:group] = NamedTuple{Tuple(by[])}(by_tup))
+
+            # label kwarg
+            if length(x[]) > 1
+                kwargs[:label] = x[]
+            elseif y_toggle[] && length(y[]) > 1
+                kwargs[:label] = y[]
+            end
+
+            # x and y labels
+            densityplot1D = plot_type[] in [cdensity, density, histogram]
+            (length(x[]) == 1 && (densityplot1D || has_y)) && (kwargs[:xlabel] = x[][1])
+            if has_y && length(y[]) == 1
+                kwargs[:ylabel] = y[][1]
+            elseif !has_y && !densityplot1D && length(x[]) == 1
+                kwargs[:ylabel] = x[][1]
+            end
+
+            plot_func = plot_function(plot_type[], has_by)
+            plot_func(args...; nbins = &nbins_throttle, kwargs...)
         end
     end
     wdg = Widget{:dataviewer}(["x" => x, "y" => y, "y_toggle" => y_toggle, "by" => by, "by_toggle" => by_toggle,

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -6,10 +6,10 @@ function dataviewer(t; throttle = 0.1, nbins = 30, nbins_range = 1:100)
     names = @map (&columns_and_names)[2]
 
     dict = @map Dict((key, convert_missing.(val)) for (val, key)  in zip((&columns_and_names)...))
-    x =  @nodeps dropdown(names, placeholder = "First axis", multiple = true)
-    y =  @nodeps dropdown(names, placeholder = "Second axis", multiple = true)
-    y_toggle = @nodeps togglecontent(y, value = false, label = "Second axis")
-    plot_type = @nodeps dropdown(
+    x =  Widgets.dropdown(names, placeholder = "First axis", multiple = true)
+    y =  Widgets.dropdown(names, placeholder = "Second axis", multiple = true)
+    y_toggle = Widgets.togglecontent(y, value = false, label = "Second axis")
+    plot_type = Widgets.dropdown(
         OrderedDict(
             "line"         => Plots.plot,
             "scatter"      => Plots.scatter,
@@ -26,13 +26,13 @@ function dataviewer(t; throttle = 0.1, nbins = 30, nbins_range = 1:100)
 
     # Add bins if the plot allows it
     display_nbins = @map (&plot_type) in [corrplot, cornerplot, histogram, marginalhist] ? "block" : "none"
-    nbins =  (@nodeps slider(nbins_range, extra_obs = ["display" => display_nbins], value = nbins, label = "number of bins"))
+    nbins =  (Widgets.slider(nbins_range, extra_obs = ["display" => display_nbins], value = nbins, label = "number of bins"))
     nbins.scope.dom = Widgets.div(nbins.scope.dom, attributes = Dict("data-bind" => "style: {display: display}"))
     nbins_throttle = Observables.throttle(throttle, nbins)
 
-    by = @nodeps dropdown(names, multiple = true, placeholder="Group by")
-    by_toggle = @nodeps togglecontent(by, value = false, label = "Split data")
-    plt = @nodeps button("plot")
+    by = Widgets.dropdown(names, multiple = true, placeholder="Group by")
+    by_toggle = Widgets.togglecontent(by, value = false, label = "Split data")
+    plt = Widgets.button("plot")
     output = @map begin
         &plt
         if (plt[] == 0)

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -85,12 +85,13 @@ recipetype(::Val{:groupedviolin}, args...) = GroupedViolin(args)
     # shift x values for each group
     group = get(plotattributes, :group, nothing)
     if group != nothing
-        ug = unique(group)
-        n = length(ug)
+        gb = Plots.extractGroupArgs(group)
+        labels, idxs = getfield(gb, 1), getfield(gb, 2)
+        n = length(labels)
         bws = plotattributes[:bar_width] / n
         bar_width := bws * clamp(1 - spacing, 0, 1)
         for i in 1:n
-            groupinds = findall(isequal(ug[i]), group)
+            groupinds = idxs[i]
             Δx = _cycle(bws, i) * (i - (n + 1) / 2)
             x[groupinds] .+= Δx
         end


### PR DESCRIPTION
This started as a simplification of the UI code (now that it is possible to use Interact widgets cleanly without depending on Interact). Halfway through I noticed that there were issues incorporating `groupedboxplot` and `groupedviolin` because, as they reimplement the grouping mechanism, they miss some cases, i.e. when `group = (vec1, vec2)` (grouping by more than one thing) and `group = (name1=vec1, name2=vec2)` (named grouping, when the legend becomes `name1 = val1, name2 = val2`) so I ported them to use the `extractGroupArgs` machinery.