### PR TITLE
fix violin number of series

### DIFF
--- a/src/violin.jl
+++ b/src/violin.jl
@@ -108,13 +108,6 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
             push!(qxsegs, [xcenter, xcenter])
             push!(qysegs, [extrema(qy)...])
-
-            @series begin
-                primary :=false
-                seriestype := :shape
-                x := [xcenter, xcenter]
-                y := [extrema(qy)...]
-            end
         end
     end
 


### PR DESCRIPTION
#215 messed up the number of series in violin plots:

```julia
using StatsPlots, DataFrames

df = DataFrame(x = repeat(["A", "B"], inner = 10), y = (1:20) .+ randn(20), g = repeat(["Group 1", "Group 2"], inner = 5, outer = 2))

@df df groupedviolin(:x, :y, group = :g)
```
![groupedviolin](https://user-images.githubusercontent.com/16589944/53946066-3f851f00-40c3-11e9-933a-e37008480808.png)

This fixes it:
![groupedviolinfixed](https://user-images.githubusercontent.com/16589944/53946087-4a3fb400-40c3-11e9-9723-66027e21ae36.png)
