### PR TITLE
Port df macro to Tables

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,9 +5,7 @@ Plots 0.14
 StatsBase
 Distributions
 KernelDensity
-IterableTables 0.5
-TableTraitsUtils 0.1
-TableTraits
+Tables
 DataValues
 Widgets 0.5.0
 Observables 0.2.2

--- a/src/StatsPlots.jl
+++ b/src/StatsPlots.jl
@@ -2,7 +2,7 @@ module StatsPlots
 
 using Reexport
 import RecipesBase: recipetype
-import Tables: istable, columntable, select, schema
+import Tables: istable, columntable, select, schema, rows
 @reexport using Plots
 import Plots: _cycle
 using Plots.PlotMeasures

--- a/src/StatsPlots.jl
+++ b/src/StatsPlots.jl
@@ -2,15 +2,13 @@ module StatsPlots
 
 using Reexport
 import RecipesBase: recipetype
+import Tables: istable, columntable, select, schema
 @reexport using Plots
 import Plots: _cycle
 using Plots.PlotMeasures
 using StatsBase
 using Distributions
-import IterableTables
 import DataValues: DataValue
-import TableTraits: getiterator, isiterabletable
-import TableTraitsUtils: create_columns_from_iterabletable
 using Widgets, Observables
 import Observables: AbstractObservable, @map, observe
 import Widgets: @nodeps


### PR DESCRIPTION
As Tables also support all iterable tables we do not lose any compatibility. We should gain some performance on tables stored column wise (like `DataFrames`) because `Tables.select` takes that into account when selecting columns and avoids allocating new ones.