### PR TITLE
Fixed Grouped Boxplot default bar_width when X is Numeric

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -5,7 +5,7 @@
 notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
 
 @recipe function f(::Type{Val{:boxplot}}, x, y, z; notch=false, range=1.5, outliers=true, whisker_width=:match)
-    # if only y is provided, then x will be UnitRange 1:length(y)
+    # if only y is provided, then x will be UnitRange 1:size(y,2)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
             x = plotattributes[:series_plotindex]
@@ -132,8 +132,9 @@ recipetype(::Val{:groupedboxplot}, args...) = GroupedBoxplot(args)
 
     # extract xnums and set default bar width.
     # might need to set xticks as well
+    ux = unique(x)
     x = if eltype(x) <: Number
-        bar_width --> (0.8 * mean(diff(x)))
+        bar_width --> (0.8 * mean(diff(sort(ux))))
         float.(x)
     else
         bar_width --> 0.8

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -138,7 +138,6 @@ recipetype(::Val{:groupedboxplot}, args...) = GroupedBoxplot(args)
         float.(x)
     else
         bar_width --> 0.8
-        ux = unique(x)
         xnums = [findfirst(isequal(xi), ux) for xi in x] .- 0.5
         xticks --> (eachindex(ux) .- 0.5, ux)
         xnums

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -20,7 +20,7 @@ get_quantiles(b::Bool) = b ? [0.5] : Float64[]
 get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
 @recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, show_mean = false, show_median = false, quantiles = Float64[])
-    # if only y is provided, then x will be UnitRange 1:length(y)
+    # if only y is provided, then x will be UnitRange 1:size(y,2)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
             x = plotattributes[:series_plotindex]


### PR DESCRIPTION
Copied the code from `groupedviolin` to `groupedboxplot` Presumably some of this should be consolidated?

Also updated the comment at the top of violin and boxplot to reflect the true behavior when x is absent.

Addresses #234