### PR TITLE
 remove compat upper version bounds 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
 
 [compat]
-julia = "1.0, 1.1"
-Plots = "0.25"
-Widgets = "0.5, 0.6"
-Observables = "0.2.2"
-RecipesBase = "0.5, 0.6"
+julia = "≧ 1.0"
+Plots = "≧ 0.25"
+Widgets = "≧ 0.5"
+Observables = "≧ 0.2.2"
+RecipesBase = "≧ 0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
 
 [compat]
-julia = "≧ 1.0"
-Plots = "≧ 0.25"
-Widgets = "≧ 0.5"
-Observables = "≧ 0.2.2"
-RecipesBase = "≧ 0.6"
+julia = "≥ 1.0"
+Plots = "≥ 0.25"
+Widgets = "≥ 0.5"
+Observables = "≥ 0.2.2"
+RecipesBase = "≥ 0.6"


### PR DESCRIPTION
I ran into a resolve issue here while locally upgrading RecipesBase to v0.7 in https://github.com/JuliaPlots/RecipesBase.jl/pull/54.
Is it ok to remove the upper bounds?