### PR TITLE
replaced isnothing with === nothing for compatbility with Julia 1.0

### DIFF
--- a/src/violin.jl
+++ b/src/violin.jl
@@ -6,7 +6,7 @@ const _violin_warned = [false]
 
 function violin_coords(y; wts = nothing, trim::Bool=false)
 
-    kd = isnothing(wts) ? KernelDensity.kde(y, npoints = 200) : KernelDensity.kde(y, weights = weights(wts), npoints = 200)
+    kd = wts === nothing ? KernelDensity.kde(y, npoints = 200) : KernelDensity.kde(y, weights = weights(wts), npoints = 200)
     if trim
         xmin, xmax = Plots.ignorenan_extrema(y)
         inside = Bool[ xmin <= x <= xmax for x in kd.x]


### PR DESCRIPTION
`isnothing(x)` was introduced in Julia 1.1 as an alias for `x === nothing`, but `isnothing` is not defined in Julia 1.0; this PR just fixes the resulting `isnothing` not defined error.