### PR TITLE
Fix stacked groupedbar with positive and negative values (close #190)

### DIFF
--- a/src/bar.jl
+++ b/src/bar.jl
@@ -46,16 +46,7 @@ grouped_xy(y::AbstractArray) = 1:size(y,1), y
 
     # compute fillrange
     fillrange := if isstack
-        # shift y/fillrange up
-        y = copy(y)
-        y[.!isfinite.(y)] .= 0
-        fr = zeros(nr, nc)
-        for c=2:nc
-            for r=1:nr
-                fr[r,c] = y[r,c-1]
-                y[r,c] += fr[r,c]
-            end
-        end
+        y, fr = groupedbar_fillrange(y)
         fr
     else
         get(plotattributes, :fillrange, nothing)
@@ -63,4 +54,25 @@ grouped_xy(y::AbstractArray) = 1:size(y,1), y
 
     seriestype := :bar
     x, y
+end
+
+function groupedbar_fillrange(y)
+    nr, nc = size(y)
+    fr = zeros(nr, nc)
+    y = copy(y)
+    y[.!isfinite.(y)] .= 0
+    for r = 1:nr
+        y_pos = y_neg = 0.0
+        for c = 1:nc
+            el = y[r, c]
+            if el >= 0
+                fr[r, c] = y_pos
+                y[r, c] = y_pos += el
+            else
+                fr[r, c] = y_neg
+                y[r, c] = y_neg += el
+            end
+        end
+    end
+    y, fr
 end


### PR DESCRIPTION
This implements @piever's suggestion based on @greimel's work in #190. 
This changes
```julia
using StatsPlots

data = [-1  2  3;
         1 -2  3;
         1  2 -3;
         1  2  3;
        -1 -2 -3]

groupedbar(data, bar_position = :stack)
```
from
![stackedbar_old](https://user-images.githubusercontent.com/16589944/62368764-d993ab00-b52d-11e9-9855-a4a5c8a907e6.png)
to
![stackedbar_new](https://user-images.githubusercontent.com/16589944/62368771-e2847c80-b52d-11e9-875a-3cda31997a87.png)
