### PR TITLE
Allow "arbitrary" arguments to corrplot

### DIFF
--- a/src/corrplot.jl
+++ b/src/corrplot.jl
@@ -2,6 +2,14 @@
 
 recipetype(::Val{:corrplot}, args...) = CorrPlot(args)
 
+"""
+    to_corrplot_matrix(mat)
+
+Transforms the input into a correlation plot matrix.  
+Meant to be overloaded by other types!
+"""
+to_corrplot_matrix(mat::AbstractMatrix) = mat
+
 function update_ticks_guides(d::KW, labs, i, j, n)
     # d[:title]  = (i==1 ? _cycle(labs,j) : "")
     # d[:xticks] = (i==n)
@@ -11,7 +19,7 @@ function update_ticks_guides(d::KW, labs, i, j, n)
 end
 
 @recipe function f(cp::CorrPlot)
-    mat = cp.args[1]
+    mat = to_corrplot_matrix(cp.args[1])
     n = size(mat,2)
     C = cor(mat)
     labs = pop!(plotattributes, :label, [""])


### PR DESCRIPTION
As of now, you can only supply matrices to corrplot; however, to my understanding, corrplot is applied relatively early in the plotting pipeline, and cannot be accessed through a seriestype.  That being said, it would be nice for user-defined types which are "`corrplot`-able" to be easily plottable through a function overload.

Therefore, I've introduced here a function `to_corrplot_matrix(mat)`, which can be overloaded by the user for their custom types.  It must return a matrix of a form which can be ingested by `corrplot`.

It would be great if there's a recipe-based solution to this that I'm missing; however, this kind of "multiple-dispatch" based recipe seems hard to implement without this kind of workaround (please tell me if I'm wrong here).  Perhaps it would be possible to introduce a plot-type-based type conversion recipe syntax, as well?