### PR TITLE
[WIP] add support for orientation=:horizontal for box & friends

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -111,10 +111,17 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
             ()
         end
     end
+    if orientation == :horizontal
+        xs = ysegs.pts
+        ys = xsegs.pts
+    else
+        xs = xsegs.pts
+        ys = ysegs.pts
+    end
 
     seriestype := :shape
-    x := xsegs.pts
-    y := ysegs.pts
+    x := xs
+    y := ys
     ()
 end
 Plots.@deps boxplot shape scatter

--- a/src/dotplot.jl
+++ b/src/dotplot.jl
@@ -45,8 +45,13 @@
     end
 
     seriestype := :scatter
-    x := points_x
-    y := points_y
+    if orientation == :horizontal
+        x := points_y
+        y := points_x
+    else
+        x := points_x
+        y := points_y
+    end
     ()
 end
 

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -114,8 +114,13 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
     @series begin
         seriestype := :shape
-        x := xsegs.pts
-        y := ysegs.pts
+        if orientation == :horizontal
+            x := ysegs.pts
+            y := xsegs.pts
+        else
+            x := xsegs.pts
+            y := ysegs.pts
+        end
         ()
     end
 
@@ -124,8 +129,13 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
             primary := false
             seriestype := :shape
             linestyle := :dot
-            x := mxsegs.pts
-            y := mysegs.pts
+            if orientation == :horizontal
+                x := mysegs.pts
+                y := mxsegs.pts
+            else
+                x := mxsegs.pts
+                y := mysegs.pts
+
             ()
         end
     end
@@ -134,8 +144,13 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
         @series begin
             primary := false
             seriestype := :shape
-            x := qxsegs.pts
-            y := qysegs.pts
+            if orientation = :horizontal
+                x := qysegs.pts
+                y := qxsegs.pts
+            else
+                x := qxsegs.pts
+                y := qysegs.pts
+            end
             ()
         end
     end


### PR DESCRIPTION
Currently, the normal versions of each of these work for the thing in the README:

```
using RDatasets

singers = RDatasets.dataset("lattice","singer")
@df singers violin(:VoicePart,:Height,marker=(0.2,:blue,stroke(0)))
@df singers boxplot!(:VoicePart,:Height,marker=(0.3,:orange,stroke(2)), alpha=0.75)
@df singers dotplot!(:VoicePart,:Height,marker=(:black,stroke(0))) 
```

But if I try `orientation=:horizontal`, for the boxplot I get

```
julia> @df singers boxplot(:Height,:VoicePart, marker=(0.3,:orange,stroke(2)), alpha=0.75, orientation=:horizontal)
ERROR: MethodError: no method matching isnan(::CategoricalString{UInt8})
Closest candidates are:
  isnan(::BigFloat) at mpfr.jl:892
  isnan(::Missing) at missing.jl:100
  isnan(::Float16) at float.jl:536
#...
```

and for dotplot and violin I get

```
julia> @df singers dotplot(:Height, :VoicePart,marker=(:black,stroke(0)), orientation=:horizontal)
ERROR: MethodError: no method matching kde(::CategoricalArray{String,1,UInt8,String,CategoricalString{UInt8},Union{}}; npoints=200)
Closest candidates are:
  kde(::AbstractArray{T,1} where T<:Real; bandwidth, kernel, npoints, boundary, weights) at /Users/ksb/.julia/packages/KernelDensity/FYY3d/src/univariate.jl:155
  kde(::AbstractArray{T,1} where T<:Real, ::R; bandwidth, kernel, weights) where R<:AbstractRange at /Users/ksb/.julia/packages/KernelDensity/FYY3d/src/univariate.jl:148 got unsupported keyword argument "npoints"
  kde(::AbstractArray{T,1} where T<:Real, ::Union{AbstractArray{T,1} where T<:Real, KernelDensity.UniformWeights}, ::R, ::Distributions.Distribution{Distributions.Univariate,S} where S<:Distributions.ValueSupport) where R<:AbstractRange at /Users/ksb/.julia/packages/KernelDensity/FYY3d/src/univariate.jl:135 got unsupported keyword argument "npoints"
```

and

```
julia> @df singers violin(:Height, :VoicePart, marker=(0.2,:blue,stroke(0)), orientation=:horizontal)
ERROR: MethodError: no method matching kde(::CategoricalArray{String,1,UInt8,String,CategoricalString{UInt8},Union{}}; npoints=200)
Closest candidates are:
  kde(::AbstractArray{T,1} where T<:Real; bandwidth, kernel, npoints, boundary, weights) at /Users/ksb/.julia/packages/KernelDensity/FYY3d/src/univariate.jl:155
  kde(::AbstractArray{T,1} where T<:Real, ::R; bandwidth, kernel, weights) where R<:AbstractRange at /Users/ksb/.julia/packages/KernelDensity/FYY3d/src/univariate.jl:148 got unsupported keyword argument "npoints"
  kde(::AbstractArray{T,1} where T<:Real, ::Union{AbstractArray{T,1} where T<:Real, KernelDensity.UniformWeights}, ::R, ::Distributions.Distribution{Distributions.Univariate,S} where S<:Distributions.ValueSupport) where R<:AbstractRange at /Users/ksb/.julia/packages/KernelDensity/FYY3d/src/univariate.jl:135 got unsupported keyword argument "npoints"
```