### PR TITLE
Fix groupedbar ordering

### DIFF
--- a/src/bar.jl
+++ b/src/bar.jl
@@ -59,16 +59,20 @@ end
 
 function groupedbar_fillrange(y)
     nr, nc = size(y)
+    # bar series fills from y[nr, nc] to fr[nr, nc], y .>= fr
     fr = zeros(nr, nc)
     y = copy(y)
     y[.!isfinite.(y)] .= 0
     for r = 1:nr
-        y_pos = y_neg = 0.0
+        y_neg = 0
+        # upper & lower bounds for positive bar
+        y_pos = sum([e for e in y[r, :] if e > 0])
+        # division subtract towards 0
         for c = 1:nc
             el = y[r, c]
             if el >= 0
                 fr[r, c] = y_pos
-                y[r, c] = y_pos += el
+                y[r, c] = y_pos -= el
             else
                 fr[r, c] = y_neg
                 y[r, c] = y_neg += el


### PR DESCRIPTION
Address #140 
```
groupedbar([[3,3] [2,-2] [1,0.5]], bar_position=:stack)
```
Before:
<img src="https://user-images.githubusercontent.com/5306213/75598258-349f6900-5a4f-11ea-9663-4dee534afb64.png" width="400">


After:
<img src="https://user-images.githubusercontent.com/5306213/75598246-26514d00-5a4f-11ea-92ad-56151a601ac6.png" width="400">
