### PR TITLE
[WIP] Grouped histogram (groupedhist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This package is a drop-in replacement for Plots.jl that contains many statistica
     - Distributions
 - Recipes:
     - histogram/histogram2d
+    - groupedhist
     - boxplot
     - dotplot
     - violin
@@ -295,6 +296,20 @@ groupedbar(nam, rand(5, 2), group = ctg, xlabel = "Groups", ylabel = "Scores",
 ```
 
 ![](https://user-images.githubusercontent.com/6645258/32116755-b7018f02-bb2a-11e7-82c7-ca471ecaeecf.png)
+
+## Grouped Histograms
+
+```
+using RDatasets
+iris = dataset("datasets", "iris)
+@df iris groupedhist(:SepalLength, :Species; bar_position = :dodge)
+```
+![dodge](https://user-images.githubusercontent.com/6033297/77240750-a11d0c00-6ba6-11ea-9715-81a8a7e20cd6.png)
+
+```
+@df iris groupedhist(:SepalLength, :Species; bar_position = :stack)
+```
+![stack](https://user-images.githubusercontent.com/6033297/77240749-9c585800-6ba6-11ea-85ea-e023341cb246.png)
 
 ## Dendrograms
 

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -72,32 +72,30 @@ Plots.group_as_matrix(g::GroupedHist) = true
     _, v = grouped_xy(p.args...)
 
     group = get(plotattributes, :group, nothing)
-    bins = get(plotattributes, :bins, :auto)
-    normed = get(plotattributes, :normalize, false)
-    weights = get(plotattributes, :weights, nothing)
-
     gb = Plots.extractGroupArgs(group)
     labels, idxs = getfield(gb, 1), getfield(gb, 2)
     ngroups = length(labels)
 
+    bins = get(plotattributes, :bins, :auto)
+    normed = get(plotattributes, :normalize, false)
+    weights = get(plotattributes, :weights, nothing)
+
     # compute edges from ungrouped data
     h = Plots._make_hist((vec(v),), bins; normed = normed, weights = weights)
     nbins = length(h.weights)
+    edges = h.edges[1]
+    bar_width --> mean(map(i -> edges[i+1] - edges[i], 1:nbins))
+    x = map(i -> (edges[i] + edges[i+1])/2, 1:nbins)
 
     # compute weights (frequencies) by group using those edges
     y = fill(NaN, nbins, ngroups)
     for i in 1:ngroups
         groupinds = idxs[i]
-        v_g = v[groupinds]
-        w_g = weights == nothing ? nothing : weights[groupinds]
-        h_g = Plots._make_hist((v_g,), h.edges; normed = false, weights = w_g)
-        y[:,i] = normed ? h_g.weights / sum(h.weights) : h_g.weights
+        v_i = v[groupinds]
+        w_i = weights == nothing ? nothing : weights[groupinds]
+        h_i = Plots._make_hist((v_i,), h.edges; normed = false, weights = w_i)
+        y[:,i] = normed ? h_i.weights / sum(h.weights) : h_i.weights
     end
-    label --> labels
-
-    edges = h.edges[1]
-    bar_width --> mean(map(i -> edges[i+1] - edges[i], 1:nbins))
-    x = map(i -> (edges[i] + edges[i+1])/2, 1:nbins)
 
     GroupedBar((x, y))
 end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -66,17 +66,18 @@ end
 
 @userplot GroupedHist
 
-@recipe function f(p::GroupedHist)
-    @assert length(p.args) == 2
-    v = p.args[1]
-    gs = p.args[2]
+Plots.group_as_matrix(g::GroupedHist) = true
 
+@recipe function f(p::GroupedHist)
+    _, v = grouped_xy(p.args...)
+
+    gs = get(plotattributes, :group, nothing)
     bins = get(plotattributes, :bins, :auto)
     normed = get(plotattributes, :normalize, false)
     weights = get(plotattributes, :weights, nothing)
 
     # compute edges from ungrouped data
-    h = Plots._make_hist((v,), bins; normed = normed, weights = weights)
+    h = Plots._make_hist((vec(v),), bins; normed = normed, weights = weights)
 
     # compute weights (frequencies) by group using those edges
     nbins = length(h.weights)


### PR DESCRIPTION
Grouped histogram produced by calling `groupedbar`. Usage:

```
using StatsPlots, RDatasets
iris = dataset("datasets", "iris")
@df iris groupedhist(:SepalLength, :Species; bar_position = :dodge)
```
![dodge](https://user-images.githubusercontent.com/6033297/77240750-a11d0c00-6ba6-11ea-9715-81a8a7e20cd6.png)

```
@df iris groupedhist(:SepalLength, :Species; bar_position = :stack)
```
![stack](https://user-images.githubusercontent.com/6033297/77240749-9c585800-6ba6-11ea-85ea-e023341cb246.png)

I couldn't figure out how to make this work using the `group` keyword argument, which is why the group IDs are passed in as the second argument instead. Also, I recognize that there's some overlap between this recipe and `stackedhist` in #315. I'd love any and all feedback!