### PR TITLE
Fix issues of marginalhist

### DIFF
--- a/src/marginalhist.jl
+++ b/src/marginalhist.jl
@@ -60,7 +60,7 @@
         left_margin --> 0mm
         bins := edges2
         y := y
-        xlims --> ylims
+        ylims --> ylims
     end
 end
 

--- a/src/marginalhist.jl
+++ b/src/marginalhist.jl
@@ -31,8 +31,8 @@
 
     # these are common to both marginal histograms
     ticks := nothing
-    xlabel := ""
-    ylabel := ""
+    xguide := ""
+    yguide := ""
     foreground_color_border := nothing
     fillcolor --> Plots.fg_color(plotattributes)
     linecolor --> Plots.fg_color(plotattributes)


### PR DESCRIPTION
There are two issues for marginalhist ATM

1. The histogram on the right side is trimmed by mistake.
2. There are warnings on using `xlable` rather than `xguide`.

This PR fixes them.