### PR TITLE
Fix `yticks` for ultrametric dendogram

### DIFF
--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -33,6 +33,13 @@ end
     xticks --> (1:nnodes(hc), string.(1:nnodes(hc))[hc.order])
     ylims --> (0, Inf)
     yshowaxis --> useheight
+    
+    xs, ys = treepositions(hc, useheight)
 
-    treepositions(hc, useheight)
+    if useheight
+        y_tick_pos = sort!(unique(ys))
+        yticks --> (y_tick_pos[2:end], string.(hc.heights ./ 2))
+    end
+
+    xs, ys
 end

--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -10,9 +10,8 @@ function treepositions(hc::Hclust, useheight::Bool)
         x2, y2 = nodepos[hc.merges[i, 2]]
 
         xpos = (x1 + x2) / 2
-        useheight ? h = hc.heights[i] : h = 1
-        ypos = max(y1, y2) + h
-
+        ypos = useheight ?  (hc.heights[i] / 2) : (max(y1, y2) + 1)
+        
         nodepos[i] = (xpos, ypos)
         xs[:, i] .= [x1, x1, x2, x2]
         ys[:, i] .= [y1, ypos, ypos, y2]
@@ -31,15 +30,7 @@ end
 
     linecolor --> :black
     xticks --> (1:nnodes(hc), string.(1:nnodes(hc))[hc.order])
-    ylims --> (0, Inf)
     yshowaxis --> useheight
     
-    xs, ys = treepositions(hc, useheight)
-
-    if useheight
-        y_tick_pos = sort!(unique(ys))
-        yticks --> (y_tick_pos[2:end], string.(hc.heights ./ 2))
-    end
-
-    xs, ys
+    treepositions(hc, useheight)
 end

--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -31,6 +31,6 @@ end
     linecolor --> :black
     xticks --> (1:nnodes(hc), string.(1:nnodes(hc))[hc.order])
     yshowaxis --> useheight
-    
+
     treepositions(hc, useheight)
 end


### PR DESCRIPTION
This solves https://github.com/JuliaStats/Clustering.jl/issues/134

Using the example in the [wiki](https://en.wikipedia.org/wiki/Complete-linkage_clustering) with this PR: 

```
using Clustering
using Plots
using StatsPlots

wiki =[
	0	17	21	31	23
	17	0	30	34	21
	21	30	0	28	39
	31	34	28	0	43
	23	21	39	43	0
]

plot(
plot(hclust(wiki, linkage=:single), xlabel="single"),
plot(hclust(wiki, linkage=:complete), xlabel="complete"),
plot(hclust(wiki, linkage=:average), xlabel="average")
)
```

![image](https://user-images.githubusercontent.com/2822757/88345186-bcab4580-cd45-11ea-844c-dabdef9e947b.png)
