### PR TITLE
Add bandwidth parameter to violin plot

### DIFF
--- a/src/violin.jl
+++ b/src/violin.jl
@@ -5,9 +5,6 @@
 const _violin_warned = [false]
 
 function violin_coords(y; wts = nothing, trim::Bool=false, bandwidth = KernelDensity.default_bandwidth(y))
-    if isnothing(bandwidth)
-        bandwidth = KernelDensity.default_bandwidth(y)
-    end
     kd = wts === nothing ?
         KernelDensity.kde(y, npoints = 200, bandwidth = bandwidth) :
         KernelDensity.kde(y, weights = weights(wts), npoints = 200, bandwidth = bandwidth)


### PR DESCRIPTION
The kernel density estimation default bandwidth can sometimes not work well for the underlying data. I added the ability to tweak the bandwidth manually to the `violin` plot.

demo
```
p_small = violin(rand(1:5, (50,2)), bandwidth = 0.25)
p_wide = violin(rand(1:5, (50,2)))
plot(p_small, p_wide)
```

![violin_bandwidth](https://user-images.githubusercontent.com/25747714/89573462-a2b73b80-d7f8-11ea-90a8-e6015530a4e3.png)

Let me know if you have any tips since I haven't contributed Julia code before.