### PR TITLE
Roll back to 0.14.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.7"
+version = "0.14.8"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.8"
+version = "0.14.9"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.6"
+version = "0.14.7"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/src/df.jl
+++ b/src/df.jl
@@ -152,7 +152,7 @@ function add_label(argnames, f, args...; kwargs...)
         if (i === nothing)
             return f(args...; kwargs...)
         else
-            return f(label = argnames[i], args...; kwargs...)
+            return f(label = stringify.(argnames[i]), args...; kwargs...)
         end
     catch e
         if e isa MethodError ||


### PR DESCRIPTION
This is a full rollback to 0.14.6 with the df macro fix appended.

We need some tests for #357 and #355 that don't rely on the RNG to figure out which commit caused this.
Tagging all the authors of the involved commits:
@Moelf, @diegozea, @PallHaraldsson, @xukai92, @yha, @HenriDeh 