### PR TITLE
Fix boxplot labels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.15"
+version = "0.14.16"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/README.md
+++ b/README.md
@@ -201,23 +201,23 @@ cornerplot(M, compact=true)
 
 ```julia
 import RDatasets
-singers = RDatasets.dataset("lattice","singer")
-@df singers violin(:VoicePart,:Height,marker=(0.2,:blue,stroke(0)))
-@df singers boxplot!(:VoicePart,:Height,marker=(0.3,:orange,stroke(2)), alpha=0.75)
-@df singers dotplot!(:VoicePart,:Height,marker=(:black,stroke(0)))
+singers = dataset("lattice", "singer")
+@df singers violin(string.(:VoicePart), :Height, linewidth=0)
+@df singers boxplot!(string.(:VoicePart), :Height, fillalpha=0.75, linewidth=2)
+@df singers dotplot!(string.(:VoicePart), :Height, marker=(:black, stroke(0)))
 ```
 
-![violin](https://user-images.githubusercontent.com/1438610/58917297-13922d80-86f4-11e9-83c0-6133a51d1d4b.png)
+![violin](https://user-images.githubusercontent.com/16589944/98538614-506c3780-228b-11eb-881c-158c2f781798.png)
 
 Asymmetric violin or dot plots can be created using the `side` keyword (`:both` - default,`:right` or `:left`), e.g.:
 
 ```julia
 singers_moscow = deepcopy(singers)
 singers_moscow[:Height] = singers_moscow[:Height] .+ 5
-@df singers violin(:VoicePart,:Height, side=:right, marker=(0.2, :blue, stroke(0)), label="Scala")
-@df singers_moscow violin!(:VoicePart,:Height, side=:left, marker=(0.2, :red, stroke(0)), label="Moscow")
-@df singers dotplot!(:VoicePart,:Height, side=:right, marker=(:black,stroke(0)), label="Scala")
-@df singers_moscow dotplot!(:VoicePart,:Height, side=:left, marker=(:black,stroke(0)), label="Moscow")
+@df singers violin(string.(:VoicePart), :Height, side=:right, linewidth=0, label="Scala")
+@df singers_moscow violin!(string.(:VoicePart), :Height, side=:left, linewidth=0, label="Moscow")
+@df singers dotplot!(string.(:VoicePart), :Height, side=:right, marker=(:black,stroke(0)), label="")
+@df singers_moscow dotplot!(string.(:VoicePart), :Height, side=:left, marker=(:black,stroke(0)), label="")
 ```
 
 Dot plots can spread their dots over the full width of their column `mode = :uniform`, or restricted to the kernel density
@@ -225,7 +225,7 @@ Dot plots can spread their dots over the full width of their column `mode = :uni
 each time the plot is recreated. `mode = :none` keeps the dots along the center.
 
 
-![violin2](https://user-images.githubusercontent.com/1438610/58917360-3e7c8180-86f4-11e9-8150-2d5e07fc0d0e.png)
+![violin2](https://user-images.githubusercontent.com/16589944/98538618-52ce9180-228b-11eb-83d2-6d7b7c89fd52.png)
 
 ---
 

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -148,15 +148,22 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
 
     end
 
-    # To prevent linecolor equal to fillcolor (It makes the median visible)
-    if plotattributes[:linecolor] == plotattributes[:fillcolor]
-        plotattributes[:linecolor] = plotattributes[:markerstrokecolor]
+    @series begin
+        # To prevent linecolor equal to fillcolor (It makes the median visible)
+        if plotattributes[:linecolor] == plotattributes[:fillcolor]
+            plotattributes[:linecolor] = plotattributes[:markerstrokecolor]
+        end
+        primary := true
+        seriestype := :shape
+        x := xsegs.pts
+        y := ysegs.pts
+        ()
     end
 
     # Outliers
     if outliers
-        primary := false
         @series begin
+            primary := false
             seriestype := :scatter
             if get!(plotattributes, :markershape, :circle) == :none
                 plotattributes[:markershape] = :circle
@@ -165,22 +172,15 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
             fillrange := nothing
             x := outliers_x
             y := outliers_y
-            primary := true
             ()
         end
     end
 
     # Hover
-    @series begin
-        seriestype := :path
-        x := xsegs.pts
-        y := ysegs.pts
-        hover := texts
-        linewidth := 0
-    end
-
-
-    seriestype := :shape
+    primary := false
+    seriestype := :path
+    hover := texts
+    linewidth := 0
     x := xsegs.pts
     y := ysegs.pts
     ()

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -179,6 +179,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     # Hover
     primary := false
     seriestype := :path
+    marker := false
     hover := texts
     linewidth := 0
     x := xsegs.pts


### PR DESCRIPTION
```julia
x = repeat(1:4, inner=30)
y = randn(120)
g = repeat(1:3, outer=40)
groupedboxplot(x, y, group=g)
```
before
![groupedboxplot_before](https://user-images.githubusercontent.com/16589944/98537895-3ed66000-228a-11eb-88f7-3ff5e20ba27d.png)
now
![groupedboxplot_now](https://user-images.githubusercontent.com/16589944/98537911-45fd6e00-228a-11eb-8312-396526c433bd.png)

EDIT: close #392