### PR TITLE
Refinements to boxplot: whiskey width, line drawing order

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -12,7 +12,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     notch = false,
     range = 1.5,
     outliers = true,
-    whisker_width = :match,
+    whisker_width = :half
 )
     # if only y is provided, then x will be UnitRange 1:size(y,2)
     if typeof(x) <: AbstractRange
@@ -28,9 +28,11 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     warning = false
     outliers_x, outliers_y = zeros(0), zeros(0)
     bw = plotattributes[:bar_width]
-    bw == nothing && (bw = 0.8)
-    @assert whisker_width == :match || whisker_width >= 0 "whisker_width must be :match or a positive number"
-    ww = whisker_width == :match ? bw : whisker_width
+    isnothing(bw) && (bw = 0.8)
+    @assert whisker_width == :match || whisker_width == :half || whisker_width >= 0 "whisker_width must be :match, :half, or a positive number"
+    ww = whisker_width == :match ? bw : 
+         whisker_width == :half ? bw / 2 :
+         whisker_width
     for (i, glabel) in enumerate(glabels)
         # filter y
         values = y[filter(i -> _cycle(x, i) == glabel, 1:length(y))]
@@ -78,7 +80,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
         end
         # Box
         push!(xsegs, m, lw, rw, m, m)       # lower T
-        push!(ysegs, q1, q1, q1, q1, q2)             # lower T
+        push!(ysegs, q1, q1, q1, q1, q2)    # lower T
         push!(
             texts,
             "Lower fence: $q1",
@@ -88,54 +90,58 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
             "Q1: $q2",
             "",
         )
-        if notch
-            push!(xsegs, l, l, L, m, R, r, r, l) # lower box
-            push!(xsegs, l, l, L, R, r, r, l) # upper box
 
-            push!(ysegs, q2, q3 - n, q3, q3, q3, q3 - n, q2, q2) # lower box
+        if notch
+            push!(xsegs, r, r, R, L, l, l, r, r) # lower box
+            push!(xsegs, r, r, l, l, L, R, r, r) # upper box
+
+            push!(ysegs, q2, q3 - n, q3, q3, q3 - n, q2, q2, q3 - n) # lower box
             push!(
                 texts,
                 "Q1: $q2",
                 "Median: $q3 ± $n",
-                "",
                 "Median: $q3 ± $n",
                 "Median: $q3 ± $n",
                 "Median: $q3 ± $n",
                 "Q1: $q2",
                 "Q1: $q2",
+                "Median: $q3 ± $n",
                 "",
             )
-            push!(ysegs, q4, q3 + n, q3, q3, q3 + n, q4, q4) # upper box
+
+            push!(ysegs, q3 + n, q4, q4, q3 + n, q3, q3, q3 + n, q4) # upper box
             push!(
                 texts,
+                "Median: $q3 ± $n",
+                "Q3: $q4",
                 "Q3: $q4",
                 "Median: $q3 ± $n",
                 "Median: $q3 ± $n",
-                "",
                 "Median: $q3 ± $n",
-                "Q3: $q4",
+                "Median: $q3 ± $n",
                 "Q3: $q4",
                 "",
             )
         else
-            push!(xsegs, l, l, m, r, r, l)         # lower box
-            push!(xsegs, l, l, r, r, l)         # upper box
-            push!(ysegs, q2, q3, q3, q3, q2, q2)    # lower box
+            push!(xsegs, r, r, l, l, r, r)         # lower box
+            push!(xsegs, r, l, l, r, r, m)         # upper box
+            push!(ysegs, q2, q3, q3, q2, q2, q3)   # lower box
             push!(
                 texts,
                 "Q1: $q2",
                 "Median: $q3",
                 "Median: $q3",
+                "Q1: $q2",
+                "Q1: $q2",
                 "Median: $q3",
-                "Q1: $q2",
-                "Q1: $q2",
                 "",
             )
-            push!(ysegs, q4, q3, q3, q4, q4)    # upper box
-            push!(texts, "Q3: $q4", "Median: $q3", "Median: $q3", "Q3: $q4", "Q3: $q4", "")
+            push!(ysegs, q4, q4, q3, q3, q4, q4)   # upper box
+            push!(texts, "Q3: $q4", "Q3: $q4", "Median: $q3", "Median: $q3", "Q3: $q4", "Q3: $q4", "")
         end
+
         push!(xsegs, m, lw, rw, m, m)             # upper T
-        push!(ysegs, q5, q5, q5, q5, q4)             # upper T
+        push!(ysegs, q5, q5, q5, q5, q4)          # upper T
         push!(
             texts,
             "Upper fence: $q5",


### PR DESCRIPTION
This PR contains two changes:

1. Default to presenting the whiskers as half-width. Full width seems unnecessary and distracts from the box, to me. Shorter whiskers seem to be the most common case when box plots are drawn elsewhere. Retained the `:match` option for those who preferred that.

2. The order of line drawing for the boxes introduced ugly mismatches when line width was increased. I rearranged so that this joint was hidden. See:

![broken](https://user-images.githubusercontent.com/1438610/105139865-dcd57a80-5ac4-11eb-9d58-a67f4e4431ad.png)
![fixed](https://user-images.githubusercontent.com/1438610/105139872-dfd06b00-5ac4-11eb-8404-503c50feb091.png)

