### PR TITLE
Use cumsum in the cdensity recipe

### DIFF
--- a/src/hist.jl
+++ b/src/hist.jl
@@ -26,7 +26,8 @@ Plots.@deps density path
         newx, newy = newy, newx
     end
 
-    newy = [sum(newy[1:i]) for i = 1:length(newy)] / sum(newy)
+    newy = cumsum(float(yi) for yi in newy)
+    newy ./= newy[end]
 
     x := newx
     y := newy


### PR DESCRIPTION
The recipe for `cdensity` computes `cumsum` but allocating all subarrays. This is incredibly wasteful. This PR uses `cumsum`. For a vector of length 1000, this part of the recipe is 100x faster.