### PR TITLE
Fixed call to RDatasets.dataset in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ cornerplot(M, compact=true)
 
 ```julia
 import RDatasets
-singers = dataset("lattice", "singer")
+singers = RDatasets.dataset("lattice", "singer")
 @df singers violin(string.(:VoicePart), :Height, linewidth=0)
 @df singers boxplot!(string.(:VoicePart), :Height, fillalpha=0.75, linewidth=2)
 @df singers dotplot!(string.(:VoicePart), :Height, marker=(:black, stroke(0)))


### PR DESCRIPTION
In the **boxplot, dotplot, and violin** section of `README.md`, the example used `import RDatasets` but  called `dataset` instead of `RDatasets.dataset`. 

I chose to use `RDatasets.dataset` instead of changing the import to `using RDatasets`, but I see that both methods are being used in README so if one is preferred over the other, I can change the PR to use the other method.