### PR TITLE
Fix dendrogram

### DIFF
--- a/src/dendrogram.jl
+++ b/src/dendrogram.jl
@@ -11,7 +11,7 @@ function treepositions(hc::Hclust, useheight::Bool, orientation=:vertical)
         x2, y2 = nodepos[hc.merges[i, 2]]
 
         xpos = (x1 + x2) / 2
-        ypos = useheight ?  (hc.heights[i] / 2) : (max(y1, y2) + 1)
+        ypos = useheight ?  hc.heights[i] : (max(y1, y2) + 1)
         
         nodepos[i] = (xpos, ypos)
         xs[:, i] .= [x1, x1, x2, x2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using StatsPlots
 using Test
 using StableRNGs
 using NaNMath
+using Clustering
 
 @testset "Grouped histogram" begin
     rng = StableRNG(1337)
@@ -28,3 +29,31 @@ using NaNMath
     @test NaNMath.maximum(gplr[1][1][:y]) == 22
     @test NaNMath.maximum(gplr[1][2][:y]) == 12
 end # testset
+
+@testset "dendrogram" begin
+    # Example from https://en.wikipedia.org/wiki/Complete-linkage_clustering
+    wiki_example = [
+		0	17	21	31	23
+		17	0	30	34	21
+		21	30	0	28	39
+		31	34	28	0	43
+		23	21	39	43	0
+	]
+    clustering = hclust(wiki_example, linkage=:complete)
+    
+    xs, ys = StatsPlots.treepositions(clustering, true, :vertical)
+
+    @test xs == [
+        2.0  1.0  4.0  1.75
+        2.0  1.0  4.0  1.75
+        3.0  2.5  5.0  4.5
+        3.0  2.5  5.0  4.5
+    ]
+
+    @test ys == [
+         0.0   0.0   0.0  23.0
+        17.0  23.0  28.0  43.0
+        17.0  23.0  28.0  43.0
+         0.0  17.0   0.0  28.0
+    ]
+end


### PR DESCRIPTION
Hi!

This fixes a minor bug I introduced in https://github.com/JuliaPlots/StatsPlots.jl/pull/356 to match the Wikipedia example. I'm sorry for that. In that example, the merged nodes' height is the **branch length**, half of the distance between the merged nodes for the ultrametric tree. That's problematic in this context, where `heights[i]` is already the `height` at which the merge node `i' should be placed. Both *Clustering.jl* and *R* considered that the height is the actual **distance** rather than the brach length, which makes much sense in combination with `hline!` and `cutree` (this is how I've realised this bug). With this simple fix, our plot matches the R plot :) Here is the [wiki example](https://en.wikipedia.org/wiki/Complete-linkage_clustering):

![image](https://user-images.githubusercontent.com/2822757/121077973-9e70fb80-c7d8-11eb-9f78-d4153af06001.png)

This also fixes https://github.com/JuliaPlots/StatsPlots.jl/issues/224 

![image](https://user-images.githubusercontent.com/2822757/121077314-c744c100-c7d7-11eb-9d8a-b2c5f230aee1.png)

Many thanks for considering my PR,

Best regards,

P.S.: Maybe, in the future, we can have `useheight` to be `:distance` (the default, this PR), `:branch_length` (previous buggy behaviour that can be useful for phylogeny) or `:none` (the actual `false`). But this minor PR should fix the problem of not matching *R* and `cutree` for the moment.