### PR TITLE
Improvements to ecdfplot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.23"
+version = "0.14.24"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -3,7 +3,7 @@
 # empirical CDF
 
 @recipe function f(ecdf::StatsBase.ECDF)
-    seriestype := :steppost
+    seriestype --> :steppost
     legend --> :topleft
     x = [ecdf.sorted_values[1]; ecdf.sorted_values]
     if :weights in propertynames(ecdf) && !isempty(ecdf.weights)

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -5,11 +5,10 @@
 @recipe function f(ecdf::StatsBase.ECDF; npoints=nothing)
     seriestype --> :steppost
     legend --> :topleft
-    xunique = unique(ecdf.sorted_values)
     if npoints !== nothing
         x = [-Inf; range(extrema(ecdf)...; length=npoints)]
     else
-        x = [-Inf; xunique]
+        x = [-Inf; unique(ecdf.sorted_values)]
     end
     y = ecdf(x)
     x, y

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -5,13 +5,10 @@
 @recipe function f(ecdf::StatsBase.ECDF)
     seriestype --> :steppost
     legend --> :topleft
-    x = [ecdf.sorted_values[1]; ecdf.sorted_values]
-    if :weights in propertynames(ecdf) && !isempty(ecdf.weights)
-         # support StatsBase versions >v0.32.0
-        y = [0; cumsum(ecdf.weights) ./ sum(ecdf.weights)]
-    else
-        y = range(0, 1; length = length(x))
-    end
+    xunique = unique(ecdf.sorted_values)
+    x = [xunique[1]; xunique]
+    y = ecdf(x)
+    y[1] = 0
     x, y
 end
 

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -6,9 +6,8 @@
     seriestype --> :steppost
     legend --> :topleft
     xunique = unique(ecdf.sorted_values)
-    x = [xunique[1]; xunique]
+    x = [-Inf; xunique]
     y = ecdf(x)
-    y[1] = 0
     x, y
 end
 

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -2,13 +2,21 @@
 # ---------------------------------------------------------------------------
 # empirical CDF
 
+function allsortedunique(x)
+    return all(eachindex(x)[1:end-1]) do i
+        @inbounds x[i] < x[i + 1]
+    end
+end
+
 @recipe function f(ecdf::StatsBase.ECDF; npoints=nothing)
     seriestype --> :steppost
     legend --> :topleft
     if npoints !== nothing
         x = [-Inf; range(extrema(ecdf)...; length=npoints)]
     else
-        x = [-Inf; unique(ecdf.sorted_values)]
+        xnonunique = ecdf.sorted_values
+        xunique = allsortedunique(xnonunique) ? xnonunique : unique(xnonunique)
+        x = [-Inf; xunique]
     end
     y = ecdf(x)
     x, y

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -22,7 +22,24 @@ end
     x, y
 end
 
+
+"""
+    ecdfplot(x; npoints = nothing)
+
+Plot the empirical cumulative distribution function (ECDF) of `x`.
+
+By default, the ECDF is evaluated at the unique points in `x`. If `npoints` is provided,
+it is instead evaluated on a uniform grid of length `npoints` between the extrema of `x`.
+This is useful when `x` is large.
+
+```julia-repl
+julia> ecdfplot(randn(100))
+
+julia> ecdfplot(randn(1_000_000); npoints=100, seriestype=:path)
+```
+"""
 @userplot ECDFPlot
+
 recipetype(::Val{:ecdfplot}, args...) = ECDFPlot(args)
 @recipe function f(p::ECDFPlot)
     x = p.args[1]

--- a/src/ecdf.jl
+++ b/src/ecdf.jl
@@ -2,11 +2,15 @@
 # ---------------------------------------------------------------------------
 # empirical CDF
 
-@recipe function f(ecdf::StatsBase.ECDF)
+@recipe function f(ecdf::StatsBase.ECDF; npoints=nothing)
     seriestype --> :steppost
     legend --> :topleft
     xunique = unique(ecdf.sorted_values)
-    x = [-Inf; xunique]
+    if npoints !== nothing
+        x = [-Inf; range(extrema(ecdf)...; length=npoints)]
+    else
+        x = [-Inf; xunique]
+    end
     y = ecdf(x)
     x, y
 end


### PR DESCRIPTION
This PR makes several improvements to `ecdfplot`:
- allow setting `seriestype` to something besides `steppost`.
- if `seriestype` is not `steppost`, don't plot the extra point on the x-axis.
- don't plot non-unique points. e.g., when plotting the ECDF of a `Binomial(50, 0.1)` sample, at most 51 points should be plotted, but previously it plotted `length(x)` points.
- allow specifying maximum number of points to plot, which is important when the sample is very large.
- add a docstring