### PR TITLE
Support plotting any UnivariateMixture

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.24"
+version = "0.14.25"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -6,8 +6,10 @@ function default_range(dist::Distribution, alpha = 0.0001)
     minval, maxval
 end
 
-function default_range(m::Distributions.MixtureModel, alpha = 0.0001)
-    mapreduce(c -> default_range(c, alpha), _minmax, m.components)
+function default_range(m::Distributions.UnivariateMixture, alpha = 0.0001)
+    mapreduce(_minmax, 1:Distributions.ncomponents(m)) do k
+        default_range(Distributions.component(m, k), alpha)
+    end
 end
 
 _minmax((xmin, xmax), (ymin, ymax)) = (min(xmin, ymin), max(xmax, ymax))
@@ -31,12 +33,13 @@ end
     (dist, yz_args(dist)...)
 end
 
-@recipe function f(m::Distributions.MixtureModel; components = true)
+@recipe function f(m::Distributions.UnivariateMixture; components = true)
     if m isa DiscreteUnivariateDistribution
         seriestype --> :sticks
     end
     if components
-        for c in m.components
+        for k in 1:Distributions.ncomponents(m)
+            c = Distributions.component(m, k)
             @series begin
                 (c, yz_args(c)...)
             end


### PR DESCRIPTION
Generalizes code for plotting `MixtureModel` to plotting `UnivariateMixture`. Fixes #448.

## Example

```julia
julia> d = MixtureModel([Normal(0, 1), Normal(4, 2)], [0.2, 0.8])
MixtureModel{Normal{Float64}}(K = 2)
components[1] (prior = 0.2000): Normal{Float64}(μ=0.0, σ=1.0)
components[2] (prior = 0.8000): Normal{Float64}(μ=4.0, σ=2.0)

julia> d2 = UnivariateGMM([0, 4], [1, 2], Categorical([0.2, 0.8]))
UnivariateGMM{Vector{Int64}, Vector{Int64}, Categorical{Float64, Vector{Float64}}}(
K: 2
means: [0, 4]
stds: [1, 2]
prior: Categorical{Float64, Vector{Float64}}(support=Base.OneTo(2), p=[0.2, 0.8])
)

julia> plot(plot(d), plot(d2))
```
![tmp](https://user-images.githubusercontent.com/8673634/124992624-8264b200-e043-11eb-81f0-5ef677ad9e87.png)
