### PR TITLE
Support drawing boxplots horizontally

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -30,7 +30,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     bw = plotattributes[:bar_width]
     isnothing(bw) && (bw = 0.8)
     @assert whisker_width == :match || whisker_width == :half || whisker_width >= 0 "whisker_width must be :match, :half, or a positive number"
-    ww = whisker_width == :match ? bw : 
+    ww = whisker_width == :match ? bw :
          whisker_width == :half ? bw / 2 :
          whisker_width
     for (i, glabel) in enumerate(glabels)
@@ -152,6 +152,15 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
             "",
         )
 
+    end
+
+    if !Plots.isvertical(plotattributes)
+        # We should draw the plot horizontally!
+        xsegs, ysegs = ysegs, xsegs
+        outliers_x, outliers_y = outliers_y, outliers_x
+
+        # Now reset the orientation, so that the axes limits are set correctly.
+        orientation := default(:orientation)
     end
 
     @series begin


### PR DESCRIPTION
Addresses https://github.com/JuliaPlots/StatsPlots.jl/issues/251

Inspired by the way that the `orientation` attribute is handled in the `bar` recipe inside `Plots.jl`