### PR TITLE
Only set hover attribute in boxplot if backend supports it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsPlots"
 uuid = "f3b207a7-027a-5e70-b257-86293d7955fd"
-version = "0.14.31"
+version = "0.14.32"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -195,7 +195,9 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     primary := false
     seriestype := :path
     marker := false
-    hover := texts
+    if Plots.is_attr_supported(Plots.backend(), :hover)
+        hover := texts
+    end
     linewidth := 0
     x := xsegs.pts
     y := ysegs.pts


### PR DESCRIPTION
Fixes #470 and part of #482 and https://github.com/fonsp/Pluto.jl/issues/1870