### PR TITLE
Add support for horizontal violin and dot plots

### DIFF
--- a/src/dotplot.jl
+++ b/src/dotplot.jl
@@ -2,7 +2,11 @@
 # ---------------------------------------------------------------------------
 # Dot Plot (strip plot, beeswarm)
 
-@recipe function f(::Type{Val{:dotplot}}, x, y, z; mode = :density, side=:both)
+@recipe function f(::Type{Val{:dotplot}}, x, y, z; 
+                        mode = :density, 
+                        side=:both,
+                        horizontal=false,
+                        )
     # if only y is provided, then x will be UnitRange 1:size(y, 2)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
@@ -29,7 +33,8 @@
         # filter y
         groupy = y[filter(i -> _cycle(x,i) == grouplabel, 1:length(y))]
 
-        center = Plots.discrete_value!(plotattributes[:subplot][:xaxis], grouplabel)[1]
+        _axis = horizontal ? :yaxis : :xaxis
+        center = Plots.discrete_value!(plotattributes[:subplot][_axis], grouplabel)[1]
         halfwidth = 0.5_cycle(barwidth, i)
 
         offsets = getoffsets(halfwidth, groupy)
@@ -45,8 +50,8 @@
     end
 
     seriestype := :scatter
-    x := points_x
-    y := points_y
+    y := horizontal ? points_x : points_y
+    x := horizontal ? points_y : points_x
     ()
 end
 

--- a/src/dotplot.jl
+++ b/src/dotplot.jl
@@ -5,7 +5,6 @@
 @recipe function f(::Type{Val{:dotplot}}, x, y, z; 
                         mode = :density, 
                         side=:both,
-                        horizontal=false,
                         )
     # if only y is provided, then x will be UnitRange 1:size(y, 2)
     if typeof(x) <: AbstractRange
@@ -28,6 +27,11 @@
         zeros(length(y))
 
     points_x, points_y = zeros(0), zeros(0)
+
+    # Get if we have to plot horizontally from the 'orientation' attribute...
+    horizontal = !Plots.isvertical(plotattributes)
+    # and reset the orientation, so that the axes limits are set correctly.
+    orientation := default(:orientation)
 
     for (i,grouplabel) in enumerate(grouplabels)
         # filter y

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -21,7 +21,15 @@ get_quantiles(x::Real) = [x]
 get_quantiles(b::Bool) = b ? [0.5] : Float64[]
 get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
-@recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both, show_mean = false, show_median = false, quantiles = Float64[], bandwidth = KernelDensity.default_bandwidth(y))
+@recipe function f(::Type{Val{:violin}}, x, y, z; 
+                    trim=true, 
+                    side=:both, 
+                    show_mean = false, 
+                    show_median = false, 
+                    quantiles = Float64[], 
+                    bandwidth = KernelDensity.default_bandwidth(y),
+                    horizontal = false,
+                    )
     # if only y is provided, then x will be UnitRange 1:size(y,2)
     if typeof(x) <: AbstractRange
         if step(x) == first(x) == 1
@@ -47,7 +55,8 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
         widths = hw * widths / Plots.ignorenan_maximum(widths)
 
         # make the violin
-        xcenter = Plots.discrete_value!(plotattributes[:subplot][:xaxis], glabel)[1]
+        _axis = horizontal ? :yaxis : :xaxis
+        xcenter = Plots.discrete_value!(plotattributes[:subplot][_axis], glabel)[1]
         xcoords = if (side==:right)
             vcat(widths, zeros(length(widths))) .+ xcenter
         elseif (side==:left)
@@ -115,8 +124,8 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
 
     @series begin
         seriestype := :shape
-        x := xsegs.pts
-        y := ysegs.pts
+        y := horizontal ? xsegs.pts : ysegs.pts
+        x := horizontal ? ysegs.pts : xsegs.pts
         ()
     end
 
@@ -125,8 +134,8 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
             primary := false
             seriestype := :shape
             linestyle := :dot
-            x := mxsegs.pts
-            y := mysegs.pts
+            y := horizontal ? mxsegs.pts : mysegs.pts
+            x := horizontal ? mysegs.pts : mxsegs.pts
             ()
         end
     end
@@ -135,8 +144,8 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
         @series begin
             primary := false
             seriestype := :shape
-            x := qxsegs.pts
-            y := qysegs.pts
+            y := horizontal ? qxsegs.pts : qysegs.pts
+            x := horizontal ? qysegs.pts : qxsegs.pts
             ()
         end
     end

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -28,7 +28,6 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
                     show_median = false, 
                     quantiles = Float64[], 
                     bandwidth = KernelDensity.default_bandwidth(y),
-                    horizontal = false,
                     )
     # if only y is provided, then x will be UnitRange 1:size(y,2)
     if typeof(x) <: AbstractRange
@@ -45,6 +44,12 @@ get_quantiles(n::Int) = range(0, 1, length = n + 2)[2:end-1]
     bw = plotattributes[:bar_width]
     bw == nothing && (bw = 0.8)
     msc = plotattributes[:markerstrokecolor]
+    
+    # Get if we have to plot horizontally from the 'orientation' attribute...
+    horizontal = !Plots.isvertical(plotattributes)
+    # and reset the orientation, so that the axes limits are set correctly.
+    orientation := default(:orientation)
+
     for (i,glabel) in enumerate(glabels)
         fy = y[filter(i -> _cycle(x,i) == glabel, 1:length(y))]
         widths, centers = violin_coords(fy, trim=trim, wts = plotattributes[:weights], bandwidth = bandwidth)


### PR DESCRIPTION
The horizontal::Bool kwarg has been added to the violin and dotplot
recipes and this allows generating horizontal versions of these plots.