### PR TITLE
boxplot: Add xshift parameter

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -13,6 +13,7 @@ notch_width(q2, q4, N) = 1.58 * (q4 - q2) / sqrt(N)
     whisker_range = 1.5,
     outliers = true,
     whisker_width = :half,
+    xshift = 0.0,
 )
     # if only y is provided, then x will be UnitRange 1:size(y,2)
     if typeof(x) <: AbstractRange
@@ -48,7 +49,7 @@ notch_width(q2, q4, N) = 1.58 * (q4 - q2) / sqrt(N)
         end
 
         # make the shape
-        center = Plots.discrete_value!(plotattributes, :x, glabel)[1]
+        center = Plots.discrete_value!(plotattributes, :x, glabel)[1] + xshift
         hw = 0.5_cycle(bw, i) # Box width
         HW = 0.5_cycle(ww, i) # Whisker width
         l, m, r = center - hw, center, center + hw


### PR DESCRIPTION
This allows drawing multiple boxplots to a single graph such as in the example below:

```julia
boxplot(s18.task, s18.time, label="2018", bar_width=0.15, xshift=0.00)
boxplot!(s19.task, s19.time, label="2019", bar_width=0.15, xshift=0.15)
boxplot!(s20.task, s20.time, label="2020", bar_width=0.15, xshift=0.30)
boxplot!(s21.task, s21.time, label="2021", bar_width=0.15, xshift=0.45)
boxplot!(s22.task, s22.time, label="2022", bar_width=0.15, xshift=0.60)
```

![image](https://user-images.githubusercontent.com/140542/216359970-bf838e9f-9cd2-4c32-a02d-98b70ee7abfb.png)

Maybe, it's possible to do it some other way, but I've not found how.