### PR TITLE
Make @df support string column names

### DIFF
--- a/src/df.jl
+++ b/src/df.jl
@@ -191,6 +191,8 @@ get_col(syms, col_nt, names) = hcat((get_col(s, col_nt, names) for s in syms)...
 
 # get the appropriate name when passed an Integer
 add_sym!(cols, i::Integer, names) = push!(cols, names[i])
+# get the appropriate name when passed a string
+add_sym!(cols, str::AbstractString, names) = add_sym!(cols, Symbol(str), names)
 # check for errors in Symbols
 add_sym!(cols, s::Symbol, names) = s in names ? push!(cols, s) : cols
 # recursively extract column names


### PR DESCRIPTION
Fixes JuliaPlots/Plots.jl#5274. Add a special case to `add_sym!` to convert an `AbstractString` column name to a `Symbol` before adding it.

The old behavior would iterate over the string and try to add each character as a column name. This produced a stack overflow, since `add_sym!` had no special case for `Char`, resulting in indefinite recursion.