### PR TITLE
Changed Orientation to Permute

### DIFF
--- a/src/cornerplot.jl
+++ b/src/cornerplot.jl
@@ -68,7 +68,7 @@ recipetype(::Val{:cornerplot}, args...) = CornerPlot(args)
     for i = 1:N
         compact && i == 1 && continue
         @series begin
-            orientation := :h
+            permute := (:x, :y)
             seriestype  := :histogram
             subplot     := indices[i + 1 - k, n]
             grid        := false


### PR DESCRIPTION
Removing the depcracted `orientation` in favour of `permute` in the cornerplot recipe.
This fixes the `ylims` issue mentioned https://github.com/JuliaPlots/Plots.jl/issues/5007 and https://github.com/TuringLang/MCMCChains.jl/issues/426 .

